### PR TITLE
fix for Steam Deck crashing when enabling this shader on ReShade Decky plugin 

### DIFF
--- a/Shaders/RGBFullToLimited.fx
+++ b/Shaders/RGBFullToLimited.fx
@@ -7,6 +7,11 @@ Convert Full RGB to Limited RGB within a Full RGB container.
 // Full range: 0 - 255
 // Limited range: 16 - 235
 
+#include "ReShade.fxh"
+
+//crashes without this for some reason
+uniform float  iGlobalTime < source = "timer"; >;
+
 // Note that RGBA8 uses a range of 0.0-1.0, so we also need to divide by 255.
 
 // RGB_Clamp: The minimum RGB value
@@ -20,14 +25,13 @@ float3(16.0/255.0, 16.0/255.0, 16.0/255.0);
 // We have to calculate the factor over the effective range, which is 235 - 16 = 219
 static const float RGB_Gain = 219.0/255.0;
 
-
-#include "ReShade.fxh"
-
 // Shader
 void FullToLimitedPass(float4 pos : SV_Position, float2 texcoord : TexCoord, out float3 color : SV_Target)
 {
-
-	color = tex2D(ReShade::BackBuffer, texcoord).rgb;
+	float4 tex = tex2D(ReShade::BackBuffer,texcoord);
+	color.r = tex.x;
+    color.g = tex.y;
+    color.b = tex.z;
 
 	color = color * RGB_Gain + RGB_Clamp;
 

--- a/Shaders/RGBFullToLimited.fx
+++ b/Shaders/RGBFullToLimited.fx
@@ -30,8 +30,8 @@ void FullToLimitedPass(float4 pos : SV_Position, float2 texcoord : TexCoord, out
 {
 	float4 tex = tex2D(ReShade::BackBuffer,texcoord);
 	color.r = tex.x;
-    color.g = tex.y;
-    color.b = tex.z;
+	color.g = tex.y;
+	color.b = tex.z;
 
 	color = color * RGB_Gain + RGB_Clamp;
 


### PR DESCRIPTION
Hi @JosVerheij I tried to use your shader (because I have the same problem with Full RGB color on my Limited RGB TV), but it was causing my Steam Deck to crash when enabling the shader from the ReShade Decky plugin.

From a look at Steam forums, [other users were seeing the same](https://steamcommunity.com/app/1675200/discussions/1/3395175706734931353/?ctp=5#c4358995818049983290).

So I troubleshooted a solution that works on the ReShade Decky Plugin. I've confirmed this change is working on my Steam Deck. I cannot say exactly *why* it works, because I'm a rookie in this Shader language area :) I compared one of the working shaders (Mattias CRT) that came with the ReShade Decky Plugin, and worked back from it to find why it worked and `RGBFullToLimited.fx` didn't.

It looks like the reference to `tex2D(ReShade::BackBuffer, texcoord).rgb` is what was causing the Steam Deck to crash for me, hence why I've adjusted how that color is retrieved from the back buffer. As for why the `uniform float ...` line needs to be there; I simply have no idea. It was a holdover from the working shader I worked back from, and if I remove it the Steam Deck crashes when enabling the shader.

I've created this Pull Request, and I'll leave it up to you whether you want to merge this or not. Perhaps this only works on the ReShade Decky plugin? I don't know. But I'd like to share this around, because using this filter with Decky seems like the quickest/easiest way to solve the problem of how to force-enable a Limited RGB range on the Steam Deck.

Let me know what you think! Maybe this version of the shader should be split into a separate 'Decky-friendly' fx file?

For reference, here's the details of my Steam Deck /ReShade / Decky:

Steam Deck:
OS Name: SteamOS Holo
OS Version: 3.5.19
OS Build: 20240422.1

Decky:
Version: 2.12.3

ReShade Decky pluing:
Version: 0.2.0